### PR TITLE
Get User list via organizationId and organizationName.

### DIFF
--- a/organization-mgt-authz-service/pom.xml
+++ b/organization-mgt-authz-service/pom.xml
@@ -31,6 +31,12 @@
     <packaging>bundle</packaging>
 
     <dependencies>
+        <!--new dependency for edu.umd.cs.findbugs.annotations-->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+            <version>${com.google.code.findbugs.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.auth.rest</groupId>
             <artifactId>org.wso2.carbon.identity.authz.service</artifactId>
@@ -135,5 +141,6 @@
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
 
         <org.wso2.carbon.identity.organization.mgt.version>0.23</org.wso2.carbon.identity.organization.mgt.version>
+        <com.google.code.findbugs.version>3.0.1</com.google.code.findbugs.version>
     </properties>
 </project>

--- a/organization-mgt-authz-service/pom.xml
+++ b/organization-mgt-authz-service/pom.xml
@@ -31,12 +31,6 @@
     <packaging>bundle</packaging>
 
     <dependencies>
-        <!--new dependency for edu.umd.cs.findbugs.annotations-->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>findbugs-annotations</artifactId>
-            <version>${com.google.code.findbugs.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.auth.rest</groupId>
             <artifactId>org.wso2.carbon.identity.authz.service</artifactId>
@@ -139,7 +133,6 @@
         <osgi.service.http.imp.pkg.version.range>[1.2.1, 2.0.0)</osgi.service.http.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
-        <com.google.code.findbugs.version>3.0.1</com.google.code.findbugs.version>
         <org.wso2.carbon.identity.organization.mgt.version>0.24</org.wso2.carbon.identity.organization.mgt.version>
     </properties>
 </project>

--- a/organization-mgt-authz-service/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/service/handler/OrganizationMgtAuthzHandler.java
+++ b/organization-mgt-authz-service/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/service/handler/OrganizationMgtAuthzHandler.java
@@ -52,6 +52,7 @@ import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWE
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
 import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.ANY_ORG;
 import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.CONDITION_SEPARATOR;
+import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.ErrorMessage.ERROR_NOT_AUTHORIZED;
 import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.FILTER_START;
 import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.HTTP_DELETE;
 import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.HTTP_GET;
@@ -179,9 +180,8 @@ public class OrganizationMgtAuthzHandler extends AuthorizationHandler {
                             }
                         }
                     } else {
-                        String errorMessage = "Error occurred while retrieving the organization id.";
-                        log.error(errorMessage);
-                        throw new AuthzServiceServerException(errorMessage);
+                        log.error(ERROR_NOT_AUTHORIZED.getCode() + ":" + ERROR_NOT_AUTHORIZED.getMessage());
+                        throw new AuthzServiceServerException(ERROR_NOT_AUTHORIZED.getCode());
                     }
                 }
             }

--- a/organization-mgt-authz-service/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/service/util/Constants.java
+++ b/organization-mgt-authz-service/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/service/util/Constants.java
@@ -23,6 +23,31 @@ package org.wso2.carbon.identity.organization.mgt.authz.service.util;
  */
 public class Constants {
 
+    public enum ErrorMessage {
+        ERROR_NOT_AUTHORIZED("ORGUAUTH_00001", "Error occurred while retrieving the organization id."),
+        ERROR_BAD_REQUEST("ORGUAUTH_00002","Error occurred due to bad request"),
+        ERROR_FORBIDDEN_REQUEST("ORGUAUTH_00003","Error occured due to forbidden request.");
+
+        private final String code;
+        private final String message;
+
+        ErrorMessage(String code, String message) {
+
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getMessage() {
+
+            return this.message;
+        }
+
+        public String getCode() {
+
+            return this.code;
+        }
+    }
+
     // SQL Constants.
     public static final String GET_IS_USER_ALLOWED = "SELECT COUNT(1) FROM ORG_AUTHZ_VIEW\n" +
             "WHERE ORG_ID = ? AND UM_USER_ID = ? AND UM_TENANT_ID = ? AND \n" +

--- a/organization-mgt-authz-valve/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/valve/OrganizationMgtAuthzValve.java
+++ b/organization-mgt-authz-valve/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/valve/OrganizationMgtAuthzValve.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.authz.service.AuthorizationManager;
 import org.wso2.carbon.identity.authz.service.AuthorizationResult;
 import org.wso2.carbon.identity.authz.service.AuthorizationStatus;
 import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerException;
+import org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants;
 import org.wso2.carbon.identity.organization.mgt.authz.valve.internal.OrganizationMgtAuthzValveServiceHolder;
 import org.wso2.carbon.identity.organization.mgt.authz.valve.util.Utils;
 import org.wso2.carbon.identity.organization.mgt.authz.service.OrgMgtAuthorizationContext;
@@ -47,6 +48,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
+import static org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants.ErrorMessage.ERROR_NOT_AUTHORIZED;
 
 /**
  * The valve for organization mgt related authorization.
@@ -119,13 +121,35 @@ public class OrganizationMgtAuthzValve extends ValveBase {
                 if (authorizationResult.getAuthorizationStatus().equals(AuthorizationStatus.GRANT)) {
                     getNext().invoke(request, response);
                 } else {
-                    handleErrorResponse(authenticationContext, response, HttpServletResponse.SC_FORBIDDEN);
+                    throw new AuthzServiceServerException(ERROR_NOT_AUTHORIZED.getCode());
                 }
             } catch (AuthzServiceServerException e) {
-                handleErrorResponse(authenticationContext, response, HttpServletResponse.SC_BAD_REQUEST);
+                if (StringUtils.equalsIgnoreCase(e.getMessage(), ERROR_NOT_AUTHORIZED.getCode())) {
+                    handleErrorResponse(authenticationContext, response, MapErrorCodes(ERROR_NOT_AUTHORIZED.getCode()));
+                } else {
+                    handleErrorResponse(authenticationContext, response, HttpServletResponse.SC_BAD_REQUEST);
+                }
             }
         } else {
             getNext().invoke(request, response);
+        }
+    }
+
+    /*
+    * @param code Error code
+    * @return error code
+    * */
+    private int MapErrorCodes(String code) {
+
+        switch (code) {
+            case "ORGUAUTH_00001":
+                return HttpServletResponse.SC_UNAUTHORIZED;
+            case "ORGUAUTH_00002":
+                return HttpServletResponse.SC_BAD_REQUEST;
+            case "ORGUAUTH_00003":
+                return HttpServletResponse.SC_FORBIDDEN;
+            default:
+                return -1;
         }
     }
 

--- a/organization-mgt-authz-valve/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/valve/OrganizationMgtAuthzValve.java
+++ b/organization-mgt-authz-valve/src/main/java/org/wso2/carbon/identity/organization/mgt/authz/valve/OrganizationMgtAuthzValve.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.identity.authz.service.AuthorizationManager;
 import org.wso2.carbon.identity.authz.service.AuthorizationResult;
 import org.wso2.carbon.identity.authz.service.AuthorizationStatus;
 import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerException;
-import org.wso2.carbon.identity.organization.mgt.authz.service.util.Constants;
 import org.wso2.carbon.identity.organization.mgt.authz.valve.internal.OrganizationMgtAuthzValveServiceHolder;
 import org.wso2.carbon.identity.organization.mgt.authz.valve.util.Utils;
 import org.wso2.carbon.identity.organization.mgt.authz.service.OrgMgtAuthorizationContext;
@@ -125,7 +124,7 @@ public class OrganizationMgtAuthzValve extends ValveBase {
                 }
             } catch (AuthzServiceServerException e) {
                 if (StringUtils.equalsIgnoreCase(e.getMessage(), ERROR_NOT_AUTHORIZED.getCode())) {
-                    handleErrorResponse(authenticationContext, response, MapErrorCodes(ERROR_NOT_AUTHORIZED.getCode()));
+                    handleErrorResponse(authenticationContext, response, mapErrorCodes(ERROR_NOT_AUTHORIZED.getCode()));
                 } else {
                     handleErrorResponse(authenticationContext, response, HttpServletResponse.SC_BAD_REQUEST);
                 }
@@ -139,7 +138,7 @@ public class OrganizationMgtAuthzValve extends ValveBase {
     * @param code Error code
     * @return error code
     * */
-    private int MapErrorCodes(String code) {
+    private int mapErrorCodes(String code) {
 
         switch (code) {
             case "ORGUAUTH_00001":


### PR DESCRIPTION
There were issues regarding when getting the users list from the organization using organization Id and organization name, since when a user uses a wrong id or name it gives two separate responses, forbidden and bad request, but we needed to give an unauthorized request. It was fixed along with adding few constants to handle the requests.